### PR TITLE
Flatpak: bump runtime to 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:6
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.1
       options: --privileged
 
     steps:

--- a/com.github.alecaddd.taxi.yml
+++ b/com.github.alecaddd.taxi.yml
@@ -1,7 +1,7 @@
 app-id: com.github.alecaddd.taxi
 
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '7.1'
 sdk: io.elementary.Sdk
 
 command: com.github.alecaddd.taxi


### PR DESCRIPTION
Can't update to 8 yet because we're using old libsoup